### PR TITLE
feat: `Repr` を deriving を使わずに実装する例を示す

### DIFF
--- a/Examples/TypeClass/Repr.lean
+++ b/Examples/TypeClass/Repr.lean
@@ -47,4 +47,52 @@ def origin : Point Nat := ⟨0, 0⟩
 #eval origin
 
 end Hidden --#
+/- ## `deriving` を使わない場合
+`Repr` のインスタンスは [`deriving`](../Command/Declarative/Deriving.md) コマンドで生成できますが，手動で作ることもできます．
+-/
+
+variable {α : Type}
+
+/-- 入れ子になったリスト -/
+inductive NestedList (α : Type) where
+| elem : α → NestedList α
+| list : List (NestedList α) → NestedList α
+
+open Std
+
+protected partial def NestedList.repr [Repr α] (a : NestedList α) (n : Nat) : Format :=
+  let _instToFormat : ToFormat (NestedList α) := ⟨(NestedList.repr · 0)⟩
+  match a, n with
+  | elem x, _ => reprPrec x n
+  | list as, _ => Format.bracket "[" (Format.joinSep as ("," ++ Format.line)) "]"
+
+def sample : NestedList Nat :=
+  .list [.elem 1, .list [.elem 2, .elem 3], .elem 4]
+
+section --#
+/-- Repr インスタンスを登録 -/
+local instance [Repr α] : Repr (NestedList α) where
+  reprPrec := NestedList.repr
+
+/-- info: [1, [2, 3], 4] -/
+#guard_msgs in #eval sample
+end --#
+
+/- あるいは，[`ToString`](./ToString.md) クラスのインスタンスがあればそこから `Lean.Eval` クラスのインスタンスも生成されて，表示に使われるので，それを利用しても良いでしょう．-/
+
+-- `ToString` クラスのインスタンスがあれば，`Lean.Eval` のインスタンスが生成できる
+example {α : Type} [ToString α] : Lean.Eval α := inferInstance
+
+/-- `NestedList` を文字列に変換 -/
+partial def NestedList.toString [ToString α] : NestedList α → String
+  | NestedList.elem x => ToString.toString x
+  | NestedList.list xs => "[" ++ String.intercalate ", " (xs.map toString) ++ "]"
+
+/-- `NestedList` の `ToString` インスタンスを宣言 -/
+instance [ToString α] : ToString (NestedList α) where
+  toString nl := NestedList.toString nl
+
+/-- info: [1, [2, 3], 4] -/
+#guard_msgs in #eval sample
+
 end Repr --#


### PR DESCRIPTION
Fixes #460