### PR TITLE
lychee のバージョンを敢えて下げる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         run: lake run build
 
       - name: Run Link Checker
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true
           args: booksrc --base booksrc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
         run: lake run build
 
       - name: Run Link Checker
+        # 敢えて古いバージョンを使用している。
+        # 最新の v2 を使用すると、lychee がまともに動作しなくなった。
         uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true


### PR DESCRIPTION
最新版を使用すると、lychee がまともに動作しなくなり、リンク切れがあっても Action が成功するという嫌な現象が起こってしまう。