### PR TITLE
where 句は修飾子として分類する

### DIFF
--- a/LeanByExample/Declarative/Def.lean
+++ b/LeanByExample/Declarative/Def.lean
@@ -21,34 +21,3 @@ def factorial (n : Nat) : Nat :=
 def add (n m : Nat) : Nat := n + m
 
 def threeAdd (n m l : Nat) : Nat := n + m + l
-
-/- ## where 句 { #Where }
-`where` 句(where clause)を使うと、定義をする前に変数を使用することができます。主に、ヘルパー関数を宣言するために使用されます。
--/
-
-/-- 自然数 `n` の素因数とその重複度のリストを返す -/
-partial def primeFactorsMult (n : Nat) : List (Nat × Nat) :=
-  loop 2 n [] |>.reverse
-where
-  /-- 自然数 `d` に対して、`n` の重複度 `μ` と `d` のペア `(d, μ)` を返す。-/
-  extract (d n : Nat) : Nat × Nat :=
-    if d ≤ 1 then
-      (1, 0)
-    else if n % d != 0 then
-      (d, 0)
-    else
-      let (d, m) := extract d (n / d)
-      (d, m + 1)
-
-  /-- ヘルパー関数 -/
-  loop (d target : Nat) (acc : List (Nat × Nat)) : List (Nat × Nat) :=
-    if target ≤ 1 then
-      acc
-    else
-      let (d, m) := extract d target
-      if m = 0 then
-        loop (d + 1) target acc
-      else
-        loop (d + 1) (target / (d ^ m)) ((d, m) :: acc)
-
-

--- a/LeanByExample/Modifier/Where.lean
+++ b/LeanByExample/Modifier/Where.lean
@@ -1,0 +1,28 @@
+/- # where
+`where` 句(where clause)を使うと、定義をする前に変数を使用することができます。主に、ヘルパー関数を宣言するために使用されます。
+-/
+
+/-- 自然数 `n` の素因数とその重複度のリストを返す -/
+partial def primeFactorsMult (n : Nat) : List (Nat × Nat) :=
+  loop 2 n [] |>.reverse
+where
+  /-- 自然数 `d` に対して、`n` の重複度 `μ` と `d` のペア `(d, μ)` を返す。-/
+  extract (d n : Nat) : Nat × Nat :=
+    if d ≤ 1 then
+      (1, 0)
+    else if n % d != 0 then
+      (d, 0)
+    else
+      let (d, m) := extract d (n / d)
+      (d, m + 1)
+
+  /-- ヘルパー関数 -/
+  loop (d target : Nat) (acc : List (Nat × Nat)) : List (Nat × Nat) :=
+    if target ≤ 1 then
+      acc
+    else
+      let (d, m) := extract d target
+      if m = 0 then
+        loop (d + 1) target acc
+      else
+        loop (d + 1) (target / (d ^ m)) ((d, m) :: acc)

--- a/booksrc/SUMMARY.md
+++ b/booksrc/SUMMARY.md
@@ -68,6 +68,7 @@
   - [scoped: 有効範囲を名前空間で限定](./Modifier/Scoped.md)
   - [termination_by: 再帰の進捗指標を指定](./Modifier/TerminationBy.md)
   - [unsafe: Leanのルールを破る](./Modifier/Unsafe.md)
+  - [where: 補助定義を追加](./Modifier/Where.md)
 
 - [構文](./Parser/README.md)
   - [⟨x₁, x₂, ..⟩: 無名コンストラクタ](./Parser/AnonymousConstructor.md)


### PR DESCRIPTION
Fixes #1593