### PR TITLE
Fix sidebar navigation overlap after mdBook update

### DIFF
--- a/theme/css/variables.css
+++ b/theme/css/variables.css
@@ -5,6 +5,8 @@
 
 :root {
   --sidebar-width: 300px;
+  --sidebar-resize-indicator-width: 8px;
+  --sidebar-resize-indicator-space: 2px;
   --page-padding: 15px;
   --content-max-width: 750px;
   --menu-bar-height: 50px;


### PR DESCRIPTION
## Summary
- define `--sidebar-resize-indicator-*` variables so the sidebar resize handle added in mdBook 0.4.36 doesn't break layout

## Testing
- `npx --yes biome format theme/css/variables.css`
- `/tmp/mdbook build` *(fails: Chapter file not found, ./README.md)*

------
https://chatgpt.com/codex/tasks/task_e_689374317a54832c95ae839b89c2f09d