### PR TITLE
fix: update theme for mdBook v0.4.41

### DIFF
--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -4,8 +4,6 @@
 */
 /* Base styles and content styles */
 
-@import 'variables.css';
-
 :root {
     /* Browser default font-size is 16px, this way 1 rem = 10px */
     font-size: 62.5%;
@@ -13,6 +11,7 @@
 }
 
 html {
+    /* 日本語を含むコンテンツでも読みやすくするためのフォント指定 */
     font-family: "Noto Sans JP", "Fira Sans", sans-serif;
     color: var(--fg);
     background-color: var(--bg);
@@ -194,6 +193,16 @@ kbd {
     line-height: 10px;
     padding: 4px 5px;
     vertical-align: middle;
+}
+
+sup {
+    /* Set the line-height for superscript and footnote references so that there
+       isn't an awkward space appearing above lines that contain the footnote.
+
+       See https://github.com/rust-lang/mdBook/pull/2443#discussion_r1813773583
+       for an explanation.
+    */
+    line-height: 0;
 }
 
 :not(.footnote-definition) + .footnote-definition,

--- a/theme/css/variables.css
+++ b/theme/css/variables.css
@@ -1,281 +1,312 @@
 /*
-ほぼ mdbook のデフォルトの CSS のままだが、フォントの指定を変更している。
+ほぼ mdbook のデフォルトの CSS のままだが、等幅フォントの指定を変更している。
 */
 /* Globals */
 
 :root {
-  --sidebar-width: 300px;
-  --sidebar-resize-indicator-width: 8px;
-  --sidebar-resize-indicator-space: 2px;
-  --page-padding: 15px;
-  --content-max-width: 750px;
-  --menu-bar-height: 50px;
-  --mono-font: "JuliaMono-Light", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
-  --code-font-size: 0.875em /* please adjust the ace font size accordingly in editor.js */
+    --sidebar-width: 300px;
+    --sidebar-resize-indicator-width: 8px;
+    --sidebar-resize-indicator-space: 2px;
+    --page-padding: 15px;
+    --content-max-width: 750px;
+    --menu-bar-height: 50px;
+    /* 日本語環境でも等幅が崩れないようにフォントを変更 */
+    --mono-font: "JuliaMono-Light", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
+    --code-font-size: 0.875em /* please adjust the ace font size accordingly in editor.js */
 }
 
 /* Themes */
 
 .ayu {
-  --bg: hsl(210, 25%, 8%);
-  --fg: #c5c5c5;
+    --bg: hsl(210, 25%, 8%);
+    --fg: #c5c5c5;
 
-  --sidebar-bg: #14191f;
-  --sidebar-fg: #c8c9db;
-  --sidebar-non-existant: #5c6773;
-  --sidebar-active: #ffb454;
-  --sidebar-spacer: #2d334f;
+    --sidebar-bg: #14191f;
+    --sidebar-fg: #c8c9db;
+    --sidebar-non-existant: #5c6773;
+    --sidebar-active: #ffb454;
+    --sidebar-spacer: #2d334f;
 
-  --scrollbar: var(--sidebar-fg);
+    --scrollbar: var(--sidebar-fg);
 
-  --icons: #737480;
-  --icons-hover: #b7b9cc;
+    --icons: #737480;
+    --icons-hover: #b7b9cc;
 
-  --links: #0096cf;
+    --links: #0096cf;
 
-  --inline-code-color: #ffb454;
+    --inline-code-color: #ffb454;
 
-  --theme-popup-bg: #14191f;
-  --theme-popup-border: #5c6773;
-  --theme-hover: #191f26;
+    --theme-popup-bg: #14191f;
+    --theme-popup-border: #5c6773;
+    --theme-hover: #191f26;
 
-  --quote-bg: hsl(226, 15%, 17%);
-  --quote-border: hsl(226, 15%, 22%);
+    --quote-bg: hsl(226, 15%, 17%);
+    --quote-border: hsl(226, 15%, 22%);
 
-  --warning-border: #ff8e00;
+    --warning-border: #ff8e00;
 
-  --table-border-color: hsl(210, 25%, 13%);
-  --table-header-bg: hsl(210, 25%, 28%);
-  --table-alternate-bg: hsl(210, 25%, 11%);
+    --table-border-color: hsl(210, 25%, 13%);
+    --table-header-bg: hsl(210, 25%, 28%);
+    --table-alternate-bg: hsl(210, 25%, 11%);
 
-  --searchbar-border-color: #848484;
-  --searchbar-bg: #424242;
-  --searchbar-fg: #fff;
-  --searchbar-shadow-color: #d4c89f;
-  --searchresults-header-fg: #666;
-  --searchresults-border-color: #888;
-  --searchresults-li-bg: #252932;
-  --search-mark-bg: #e3b171;
+    --searchbar-border-color: #848484;
+    --searchbar-bg: #424242;
+    --searchbar-fg: #fff;
+    --searchbar-shadow-color: #d4c89f;
+    --searchresults-header-fg: #666;
+    --searchresults-border-color: #888;
+    --searchresults-li-bg: #252932;
+    --search-mark-bg: #e3b171;
 
-  --color-scheme: dark;
+    --color-scheme: dark;
+
+    /* Same as `--icons` */
+    --copy-button-filter: invert(45%) sepia(6%) saturate(621%) hue-rotate(198deg) brightness(99%) contrast(85%);
+    /* Same as `--sidebar-active` */
+    --copy-button-filter-hover: invert(68%) sepia(55%) saturate(531%) hue-rotate(341deg) brightness(104%) contrast(101%);
 }
 
 .coal {
-  --bg: hsl(200, 7%, 8%);
-  --fg: #98a3ad;
+    --bg: hsl(200, 7%, 8%);
+    --fg: #98a3ad;
 
-  --sidebar-bg: #292c2f;
-  --sidebar-fg: #a1adb8;
-  --sidebar-non-existant: #505254;
-  --sidebar-active: #3473ad;
-  --sidebar-spacer: #393939;
+    --sidebar-bg: #292c2f;
+    --sidebar-fg: #a1adb8;
+    --sidebar-non-existant: #505254;
+    --sidebar-active: #3473ad;
+    --sidebar-spacer: #393939;
 
-  --scrollbar: var(--sidebar-fg);
+    --scrollbar: var(--sidebar-fg);
 
-  --icons: #43484d;
-  --icons-hover: #b3c0cc;
+    --icons: #43484d;
+    --icons-hover: #b3c0cc;
 
-  --links: #2b79a2;
+    --links: #2b79a2;
 
-  --inline-code-color: #c5c8c6;
+    --inline-code-color: #c5c8c6;
 
-  --theme-popup-bg: #141617;
-  --theme-popup-border: #43484d;
-  --theme-hover: #1f2124;
+    --theme-popup-bg: #141617;
+    --theme-popup-border: #43484d;
+    --theme-hover: #1f2124;
 
-  --quote-bg: hsl(234, 21%, 18%);
-  --quote-border: hsl(234, 21%, 23%);
+    --quote-bg: hsl(234, 21%, 18%);
+    --quote-border: hsl(234, 21%, 23%);
 
-  --warning-border: #ff8e00;
+    --warning-border: #ff8e00;
 
-  --table-border-color: hsl(200, 7%, 13%);
-  --table-header-bg: hsl(200, 7%, 28%);
-  --table-alternate-bg: hsl(200, 7%, 11%);
+    --table-border-color: hsl(200, 7%, 13%);
+    --table-header-bg: hsl(200, 7%, 28%);
+    --table-alternate-bg: hsl(200, 7%, 11%);
 
-  --searchbar-border-color: #aaa;
-  --searchbar-bg: #b7b7b7;
-  --searchbar-fg: #000;
-  --searchbar-shadow-color: #aaa;
-  --searchresults-header-fg: #666;
-  --searchresults-border-color: #98a3ad;
-  --searchresults-li-bg: #2b2b2f;
-  --search-mark-bg: #355c7d;
+    --searchbar-border-color: #aaa;
+    --searchbar-bg: #b7b7b7;
+    --searchbar-fg: #000;
+    --searchbar-shadow-color: #aaa;
+    --searchresults-header-fg: #666;
+    --searchresults-border-color: #98a3ad;
+    --searchresults-li-bg: #2b2b2f;
+    --search-mark-bg: #355c7d;
 
-  --color-scheme: dark;
+    --color-scheme: dark;
+
+    /* Same as `--icons` */
+    --copy-button-filter: invert(26%) sepia(8%) saturate(575%) hue-rotate(169deg) brightness(87%) contrast(82%);
+    /* Same as `--sidebar-active` */
+    --copy-button-filter-hover: invert(36%) sepia(70%) saturate(503%) hue-rotate(167deg) brightness(98%) contrast(89%);
 }
 
-.light {
-  --bg: hsl(0, 0%, 100%);
-  --fg: hsl(0, 0%, 0%);
+.light, html:not(.js) {
+    --bg: hsl(0, 0%, 100%);
+    --fg: hsl(0, 0%, 0%);
 
-  --sidebar-bg: #fafafa;
-  --sidebar-fg: hsl(0, 0%, 0%);
-  --sidebar-non-existant: #aaaaaa;
-  --sidebar-active: #1f1fff;
-  --sidebar-spacer: #f4f4f4;
+    --sidebar-bg: #fafafa;
+    --sidebar-fg: hsl(0, 0%, 0%);
+    --sidebar-non-existant: #aaaaaa;
+    --sidebar-active: #1f1fff;
+    --sidebar-spacer: #f4f4f4;
 
-  --scrollbar: #8F8F8F;
+    --scrollbar: #8F8F8F;
 
-  --icons: #747474;
-  --icons-hover: #000000;
+    --icons: #747474;
+    --icons-hover: #000000;
 
-  --links: #20609f;
+    --links: #20609f;
 
-  --inline-code-color: #301900;
+    --inline-code-color: #301900;
 
-  --theme-popup-bg: #fafafa;
-  --theme-popup-border: #cccccc;
-  --theme-hover: #e6e6e6;
+    --theme-popup-bg: #fafafa;
+    --theme-popup-border: #cccccc;
+    --theme-hover: #e6e6e6;
 
-  --quote-bg: hsl(197, 37%, 96%);
-  --quote-border: hsl(197, 37%, 91%);
+    --quote-bg: hsl(197, 37%, 96%);
+    --quote-border: hsl(197, 37%, 91%);
 
-  --warning-border: #ff8e00;
+    --warning-border: #ff8e00;
 
-  --table-border-color: hsl(0, 0%, 95%);
-  --table-header-bg: hsl(0, 0%, 80%);
-  --table-alternate-bg: hsl(0, 0%, 97%);
+    --table-border-color: hsl(0, 0%, 95%);
+    --table-header-bg: hsl(0, 0%, 80%);
+    --table-alternate-bg: hsl(0, 0%, 97%);
 
-  --searchbar-border-color: #aaa;
-  --searchbar-bg: #fafafa;
-  --searchbar-fg: #000;
-  --searchbar-shadow-color: #aaa;
-  --searchresults-header-fg: #666;
-  --searchresults-border-color: #888;
-  --searchresults-li-bg: #e4f2fe;
-  --search-mark-bg: #a2cff5;
+    --searchbar-border-color: #aaa;
+    --searchbar-bg: #fafafa;
+    --searchbar-fg: #000;
+    --searchbar-shadow-color: #aaa;
+    --searchresults-header-fg: #666;
+    --searchresults-border-color: #888;
+    --searchresults-li-bg: #e4f2fe;
+    --search-mark-bg: #a2cff5;
 
-  --color-scheme: light;
+    --color-scheme: light;
+
+    /* Same as `--icons` */
+    --copy-button-filter: invert(45.49%);
+    /* Same as `--sidebar-active` */
+    --copy-button-filter-hover: invert(14%) sepia(93%) saturate(4250%) hue-rotate(243deg) brightness(99%) contrast(130%);
 }
 
 .navy {
-  --bg: hsl(226, 23%, 11%);
-  --fg: #bcbdd0;
+    --bg: hsl(226, 23%, 11%);
+    --fg: #bcbdd0;
 
-  --sidebar-bg: #282d3f;
-  --sidebar-fg: #c8c9db;
-  --sidebar-non-existant: #505274;
-  --sidebar-active: #2b79a2;
-  --sidebar-spacer: #2d334f;
+    --sidebar-bg: #282d3f;
+    --sidebar-fg: #c8c9db;
+    --sidebar-non-existant: #505274;
+    --sidebar-active: #2b79a2;
+    --sidebar-spacer: #2d334f;
 
-  --scrollbar: var(--sidebar-fg);
+    --scrollbar: var(--sidebar-fg);
 
-  --icons: #737480;
-  --icons-hover: #b7b9cc;
+    --icons: #737480;
+    --icons-hover: #b7b9cc;
 
-  --links: #2b79a2;
+    --links: #2b79a2;
 
-  --inline-code-color: #c5c8c6;
+    --inline-code-color: #c5c8c6;
 
-  --theme-popup-bg: #161923;
-  --theme-popup-border: #737480;
-  --theme-hover: #282e40;
+    --theme-popup-bg: #161923;
+    --theme-popup-border: #737480;
+    --theme-hover: #282e40;
 
-  --quote-bg: hsl(226, 15%, 17%);
-  --quote-border: hsl(226, 15%, 22%);
+    --quote-bg: hsl(226, 15%, 17%);
+    --quote-border: hsl(226, 15%, 22%);
 
-  --warning-border: #ff8e00;
+    --warning-border: #ff8e00;
 
-  --table-border-color: hsl(226, 23%, 16%);
-  --table-header-bg: hsl(226, 23%, 31%);
-  --table-alternate-bg: hsl(226, 23%, 14%);
+    --table-border-color: hsl(226, 23%, 16%);
+    --table-header-bg: hsl(226, 23%, 31%);
+    --table-alternate-bg: hsl(226, 23%, 14%);
 
-  --searchbar-border-color: #aaa;
-  --searchbar-bg: #aeaec6;
-  --searchbar-fg: #000;
-  --searchbar-shadow-color: #aaa;
-  --searchresults-header-fg: #5f5f71;
-  --searchresults-border-color: #5c5c68;
-  --searchresults-li-bg: #242430;
-  --search-mark-bg: #a2cff5;
+    --searchbar-border-color: #aaa;
+    --searchbar-bg: #aeaec6;
+    --searchbar-fg: #000;
+    --searchbar-shadow-color: #aaa;
+    --searchresults-header-fg: #5f5f71;
+    --searchresults-border-color: #5c5c68;
+    --searchresults-li-bg: #242430;
+    --search-mark-bg: #a2cff5;
 
-  --color-scheme: dark;
+    --color-scheme: dark;
+
+    /* Same as `--icons` */
+    --copy-button-filter: invert(51%) sepia(10%) saturate(393%) hue-rotate(198deg) brightness(86%) contrast(87%);
+    /* Same as `--sidebar-active` */
+    --copy-button-filter-hover: invert(46%) sepia(20%) saturate(1537%) hue-rotate(156deg) brightness(85%) contrast(90%);
 }
 
 .rust {
-  --bg: hsl(60, 9%, 87%);
-  --fg: #262625;
+    --bg: hsl(60, 9%, 87%);
+    --fg: #262625;
 
-  --sidebar-bg: #3b2e2a;
-  --sidebar-fg: #c8c9db;
-  --sidebar-non-existant: #505254;
-  --sidebar-active: #e69f67;
-  --sidebar-spacer: #45373a;
+    --sidebar-bg: #3b2e2a;
+    --sidebar-fg: #c8c9db;
+    --sidebar-non-existant: #505254;
+    --sidebar-active: #e69f67;
+    --sidebar-spacer: #45373a;
 
-  --scrollbar: var(--sidebar-fg);
+    --scrollbar: var(--sidebar-fg);
 
-  --icons: #737480;
-  --icons-hover: #262625;
+    --icons: #737480;
+    --icons-hover: #262625;
 
-  --links: #2b79a2;
+    --links: #2b79a2;
 
-  --inline-code-color: #6e6b5e;
+    --inline-code-color: #6e6b5e;
 
-  --theme-popup-bg: #e1e1db;
-  --theme-popup-border: #b38f6b;
-  --theme-hover: #99908a;
+    --theme-popup-bg: #e1e1db;
+    --theme-popup-border: #b38f6b;
+    --theme-hover: #99908a;
 
-  --quote-bg: hsl(60, 5%, 75%);
-  --quote-border: hsl(60, 5%, 70%);
+    --quote-bg: hsl(60, 5%, 75%);
+    --quote-border: hsl(60, 5%, 70%);
 
-  --warning-border: #ff8e00;
+    --warning-border: #ff8e00;
 
-  --table-border-color: hsl(60, 9%, 82%);
-  --table-header-bg: #b3a497;
-  --table-alternate-bg: hsl(60, 9%, 84%);
+    --table-border-color: hsl(60, 9%, 82%);
+    --table-header-bg: #b3a497;
+    --table-alternate-bg: hsl(60, 9%, 84%);
 
-  --searchbar-border-color: #aaa;
-  --searchbar-bg: #fafafa;
-  --searchbar-fg: #000;
-  --searchbar-shadow-color: #aaa;
-  --searchresults-header-fg: #666;
-  --searchresults-border-color: #888;
-  --searchresults-li-bg: #dec2a2;
-  --search-mark-bg: #e69f67;
+    --searchbar-border-color: #aaa;
+    --searchbar-bg: #fafafa;
+    --searchbar-fg: #000;
+    --searchbar-shadow-color: #aaa;
+    --searchresults-header-fg: #666;
+    --searchresults-border-color: #888;
+    --searchresults-li-bg: #dec2a2;
+    --search-mark-bg: #e69f67;
 
-  --color-scheme: light;
+    /* Same as `--icons` */
+    --copy-button-filter: invert(51%) sepia(10%) saturate(393%) hue-rotate(198deg) brightness(86%) contrast(87%);
+    /* Same as `--sidebar-active` */
+    --copy-button-filter-hover: invert(77%) sepia(16%) saturate(1798%) hue-rotate(328deg) brightness(98%) contrast(83%);
 }
 
 @media (prefers-color-scheme: dark) {
-  .light.no-js {
-      --bg: hsl(200, 7%, 8%);
-      --fg: #98a3ad;
+    html:not(.js) {
+        --bg: hsl(200, 7%, 8%);
+        --fg: #98a3ad;
 
-      --sidebar-bg: #292c2f;
-      --sidebar-fg: #a1adb8;
-      --sidebar-non-existant: #505254;
-      --sidebar-active: #3473ad;
-      --sidebar-spacer: #393939;
+        --sidebar-bg: #292c2f;
+        --sidebar-fg: #a1adb8;
+        --sidebar-non-existant: #505254;
+        --sidebar-active: #3473ad;
+        --sidebar-spacer: #393939;
 
-      --scrollbar: var(--sidebar-fg);
+        --scrollbar: var(--sidebar-fg);
 
-      --icons: #43484d;
-      --icons-hover: #b3c0cc;
+        --icons: #43484d;
+        --icons-hover: #b3c0cc;
 
-      --links: #2b79a2;
+        --links: #2b79a2;
 
-      --inline-code-color: #c5c8c6;
+        --inline-code-color: #c5c8c6;
 
-      --theme-popup-bg: #141617;
-      --theme-popup-border: #43484d;
-      --theme-hover: #1f2124;
+        --theme-popup-bg: #141617;
+        --theme-popup-border: #43484d;
+        --theme-hover: #1f2124;
 
-      --quote-bg: hsl(234, 21%, 18%);
-      --quote-border: hsl(234, 21%, 23%);
+        --quote-bg: hsl(234, 21%, 18%);
+        --quote-border: hsl(234, 21%, 23%);
 
-      --warning-border: #ff8e00;
+        --warning-border: #ff8e00;
 
-      --table-border-color: hsl(200, 7%, 13%);
-      --table-header-bg: hsl(200, 7%, 28%);
-      --table-alternate-bg: hsl(200, 7%, 11%);
+        --table-border-color: hsl(200, 7%, 13%);
+        --table-header-bg: hsl(200, 7%, 28%);
+        --table-alternate-bg: hsl(200, 7%, 11%);
 
-      --searchbar-border-color: #aaa;
-      --searchbar-bg: #b7b7b7;
-      --searchbar-fg: #000;
-      --searchbar-shadow-color: #aaa;
-      --searchresults-header-fg: #666;
-      --searchresults-border-color: #98a3ad;
-      --searchresults-li-bg: #2b2b2f;
-      --search-mark-bg: #355c7d;
-  }
+        --searchbar-border-color: #aaa;
+        --searchbar-bg: #b7b7b7;
+        --searchbar-fg: #000;
+        --searchbar-shadow-color: #aaa;
+        --searchresults-header-fg: #666;
+        --searchresults-border-color: #98a3ad;
+        --searchresults-li-bg: #2b2b2f;
+        --search-mark-bg: #355c7d;
+
+        --color-scheme: dark;
+
+        /* Same as `--icons` */
+        --copy-button-filter: invert(26%) sepia(8%) saturate(575%) hue-rotate(169deg) brightness(87%) contrast(82%);
+        /* Same as `--sidebar-active` */
+        --copy-button-filter-hover: invert(36%) sepia(70%) saturate(503%) hue-rotate(167deg) brightness(98%) contrast(89%);
+    }
 }

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -1,62 +1,59 @@
 <!DOCTYPE HTML>
-<html lang="{{ language }}" class="{{ default_theme }}" dir="{{ text_direction }}">
+<html lang="{{ language }}" class="{{ default_theme }} sidebar-visible" dir="{{ text_direction }}">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>{{ title }}</title>
+        {{#if is_print }}
+        <meta name="robots" content="noindex">
+        {{/if}}
+        {{#if base_url}}
+        <base href="{{ base_url }}">
+        {{/if}}
 
-<head>
-    <!-- Book generated using mdBook -->
-    <meta charset="UTF-8">
-    <title>{{ title }}</title>
-    {{#if is_print }}
-    <meta name="robots" content="noindex">
-    {{/if}}
-    {{#if base_url}}
-    <base href="{{ base_url }}">
-    {{/if}}
 
+        <!-- Custom HTML head -->
+        {{> head}}
 
-    <!-- Custom HTML head -->
-    {{> head}}
+        <meta name="description" content="{{ description }}">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff">
 
-    <meta name="description" content="{{ description }}">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#ffffff">
+        {{#if favicon_svg}}
+        <link rel="icon" href="{{ path_to_root }}favicon.svg">
+        {{/if}}
+        {{#if favicon_png}}
+        <link rel="shortcut icon" href="{{ path_to_root }}favicon.png">
+        {{/if}}
+        <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">
+        <link rel="stylesheet" href="{{ path_to_root }}css/general.css">
+        <link rel="stylesheet" href="{{ path_to_root }}css/chrome.css">
+        {{#if print_enable}}
+        <link rel="stylesheet" href="{{ path_to_root }}css/print.css" media="print">
+        {{/if}}
 
-    {{#if favicon_svg}}
-    <link rel="icon" href="{{ path_to_root }}favicon.svg">
-    {{/if}}
-    {{#if favicon_png}}
-    <link rel="shortcut icon" href="{{ path_to_root }}favicon.png">
-    {{/if}}
-    <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">
-    <link rel="stylesheet" href="{{ path_to_root }}css/general.css">
-    <link rel="stylesheet" href="{{ path_to_root }}css/chrome.css">
-    {{#if print_enable}}
-    <link rel="stylesheet" href="{{ path_to_root }}css/print.css" media="print">
-    {{/if}}
+        <!-- Fonts -->
+        <link rel="stylesheet" href="{{ path_to_root }}FontAwesome/css/font-awesome.css">
+        {{#if copy_fonts}}
+        <link rel="stylesheet" href="{{ path_to_root }}fonts/fonts.css">
+        {{/if}}
 
-    <!-- Fonts -->
-    <link rel="stylesheet" href="{{ path_to_root }}FontAwesome/css/font-awesome.css">
-    {{#if copy_fonts}}
-    <link rel="stylesheet" href="{{ path_to_root }}fonts/fonts.css">
-    {{/if}}
+        <!-- Highlight.js Stylesheets -->
+        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
+        <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
 
-    <!-- Highlight.js Stylesheets -->
-    <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
-    <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
-    <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{ ../path_to_root }}{{ this }}">
+        {{/each}}
 
-    <!-- Custom theme stylesheets -->
-    {{#each additional_css}}
-    <link rel="stylesheet" href="{{ ../path_to_root }}{{ this }}">
-    {{/each}}
-
-    {{#if mathjax_support}}
-    <!-- MathJax -->
-    <script async
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    {{/if}}
-</head>
-
-<body class="sidebar-visible no-js">
+        {{#if mathjax_support}}
+        <!-- MathJax -->
+        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        {{/if}}
+    </head>
+    <body>
     <div id="body-container">
         <!-- Provide site root to javascript -->
         <script>
@@ -83,35 +80,34 @@
         <!-- Set the theme before any content is loaded, prevents flash -->
         <script>
             var theme;
-            try { theme = localStorage.getItem('mdbook-theme'); } catch (e) { }
+            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
             if (theme === null || theme === undefined) { theme = default_theme; }
-            var html = document.querySelector('html');
+            const html = document.documentElement;
             html.classList.remove('{{ default_theme }}')
             html.classList.add(theme);
-            var body = document.querySelector('body');
-            body.classList.remove('no-js')
-            body.classList.add('js');
+            html.classList.add("js");
         </script>
 
         <input type="checkbox" id="sidebar-toggle-anchor" class="hidden">
 
         <!-- Hide / unhide sidebar before it is displayed -->
         <script>
-            var body = document.querySelector('body');
             var sidebar = null;
             var sidebar_toggle = document.getElementById("sidebar-toggle-anchor");
             if (document.body.clientWidth >= 1080) {
-                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch (e) { }
+                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';
             } else {
                 sidebar = 'hidden';
             }
             sidebar_toggle.checked = sidebar === 'visible';
-            body.classList.remove('sidebar-visible');
-            body.classList.add("sidebar-" + sidebar);
+            html.classList.remove('sidebar-visible');
+            html.classList.add("sidebar-" + sidebar);
         </script>
 
         <nav id="sidebar" class="sidebar" aria-label="Table of contents">
+            {{! v0.4.41 から toc.js を利用して目次を共通ファイルから読み込む方式になったが、 }}
+            {{! オフライン環境でも確実に動作させるため従来どおり静的に目次を埋め込む。 }}
             <div class="sidebar-scrollbox">
                 {{#toc}}{{/toc}}
             </div>
@@ -120,28 +116,6 @@
             </div>
         </nav>
 
-        <!-- Track and set sidebar scroll position -->
-        <script>
-            var sidebarScrollbox = document.querySelector('#sidebar .sidebar-scrollbox');
-            sidebarScrollbox.addEventListener('click', function (e) {
-                if (e.target.tagName === 'A') {
-                    sessionStorage.setItem('sidebar-scroll', sidebarScrollbox.scrollTop);
-                }
-            }, { passive: true });
-            var sidebarScrollTop = sessionStorage.getItem('sidebar-scroll');
-            sessionStorage.removeItem('sidebar-scroll');
-            if (sidebarScrollTop) {
-                // preserve sidebar scroll position when navigating via links within sidebar
-                sidebarScrollbox.scrollTop = sidebarScrollTop;
-            } else {
-                // scroll sidebar to current active section when navigating via "next/previous chapter" buttons
-                var activeSection = document.querySelector('#sidebar .active');
-                if (activeSection) {
-                    activeSection.scrollIntoView({ block: 'center' });
-                }
-            }
-        </script>
-
         <div id="page-wrapper" class="page-wrapper">
 
             <div class="page">
@@ -149,14 +123,10 @@
                 <div id="menu-bar-hover-placeholder"></div>
                 <div id="menu-bar" class="menu-bar sticky">
                     <div class="left-buttons">
-                        <label id="sidebar-toggle" class="icon-button" for="sidebar-toggle-anchor"
-                            title="Toggle Table of Contents" aria-label="Toggle Table of Contents"
-                            aria-controls="sidebar">
+                        <label id="sidebar-toggle" class="icon-button" for="sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="sidebar">
                             <i class="fa fa-bars"></i>
                         </label>
-                        <button id="theme-toggle" class="icon-button" type="button" title="Change theme"
-                            aria-label="Change theme" aria-haspopup="true" aria-expanded="false"
-                            aria-controls="theme-list">
+                        <button id="theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="theme-list">
                             <i class="fa fa-paint-brush"></i>
                         </button>
                         <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
@@ -167,9 +137,7 @@
                             <li role="none"><button role="menuitem" class="theme" id="ayu">Ayu</button></li>
                         </ul>
                         {{#if search_enabled}}
-                        <button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)"
-                            aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S"
-                            aria-controls="searchbar">
+                        <button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">
                             <i class="fa fa-search"></i>
                         </button>
                         {{/if}}
@@ -178,28 +146,30 @@
                     <h1 class="menu-title">{{ book_title }}</h1>
 
                     <div class="right-buttons">
+                        {{#if print_enable}}
+                        <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
+                            <i id="print-button" class="fa fa-print"></i>
+                        </a>
+                        {{/if}}
                         {{#if git_repository_url}}
                         <a href="{{git_repository_url}}" title="Git repository" aria-label="Git repository">
                             <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                         </a>
                         {{/if}}
-                        {{!--
-                            本来編集ページへのリンクだが、改造してファイル単位の実行ボタンにしている
-                        --}}
                         {{#if git_repository_edit_url}}
-                        <a href="{{git_repository_edit_url}}" title="Run on Lean 4 playground" aria-label="Run on Lean 4 playground"
-                            target=_blank>
+                        <a href="{{git_repository_edit_url}}" title="Run on Lean 4 playground" aria-label="Run on Lean 4 playground" target="_blank">
+                            {{! 編集リンクを Lean 4 Playground で実行するボタンに差し替えている }}
                             <i id="lean-play-button" class="fa fa-play"></i>
                         </a>
                         {{/if}}
+
                     </div>
                 </div>
 
                 {{#if search_enabled}}
                 <div id="search-wrapper" class="hidden">
                     <form id="searchbar-outer" class="searchbar-outer">
-                        <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..."
-                            aria-controls="searchresults-outer" aria-describedby="searchresults-header">
+                        <input type="search" id="searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="searchresults-outer" aria-describedby="searchresults-header">
                     </form>
                     <div id="searchresults-outer" class="searchresults-outer hidden">
                         <div id="searchresults-header" class="searchresults-header"></div>
@@ -213,16 +183,18 @@
                 <script>
                     document.getElementById('sidebar-toggle').setAttribute('aria-expanded', sidebar === 'visible');
                     document.getElementById('sidebar').setAttribute('aria-hidden', sidebar !== 'visible');
-                    Array.from(document.querySelectorAll('#sidebar a')).forEach(function (link) {
+                    Array.from(document.querySelectorAll('#sidebar a')).forEach(function(link) {
                         link.setAttribute('tabIndex', sidebar === 'visible' ? 0 : -1);
                     });
                 </script>
 
                 <div id="content" class="content">
                     <main>
+                        {{! ページ本体を囲むラッパー。右側にページ内目次を表示するため追加している。 }}
                         <div class="content-wrap">
                             {{{ content }}}
                         </div>
+                        {{! ページ内の見出しを右側に表示するナビゲーション。 }}
                         <div class="sidetoc">
                             <nav class="pagetoc"></nav>
                         </div>
@@ -231,17 +203,15 @@
                     <nav class="nav-wrapper" aria-label="Page navigation">
                         <!-- Mobile navigation buttons -->
                         {{#previous}}
-                        <a rel="prev" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters previous"
-                            title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
-                            <i class="fa fa-angle-left"></i>
-                        </a>
+                            <a rel="prev" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                                <i class="fa fa-angle-left"></i>
+                            </a>
                         {{/previous}}
 
                         {{#next}}
-                        <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters next"
-                            title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
-                            <i class="fa fa-angle-right"></i>
-                        </a>
+                            <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                                <i class="fa fa-angle-right"></i>
+                            </a>
                         {{/next}}
 
                         <div style="clear: both"></div>
@@ -251,17 +221,15 @@
 
             <nav class="nav-wide-wrapper" aria-label="Page navigation">
                 {{#previous}}
-                <a rel="prev" href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter"
-                    aria-label="Previous chapter" aria-keyshortcuts="Left">
-                    <i class="fa fa-angle-left"></i>
-                </a>
+                    <a rel="prev" href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                        <i class="fa fa-angle-left"></i>
+                    </a>
                 {{/previous}}
 
                 {{#next}}
-                <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="nav-chapters next" title="Next chapter"
-                    aria-label="Next chapter" aria-keyshortcuts="Right">
-                    <i class="fa fa-angle-right"></i>
-                </a>
+                    <a rel="next prefetch" href="{{ path_to_root }}{{link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                        <i class="fa fa-angle-right"></i>
+                    </a>
                 {{/next}}
             </nav>
 
@@ -280,8 +248,27 @@
                 }
             };
 
-            window.onbeforeunload = function () {
+            window.onbeforeunload = function() {
                 socket.close();
+            }
+        </script>
+        {{/if}}
+
+        {{#if google_analytics}}
+        <!-- Google Analytics Tag -->
+        <script>
+            var localAddrs = ["localhost", "127.0.0.1", ""];
+
+            // make sure we don't activate google analytics if the developer is
+            // inspecting the book locally...
+            if (localAddrs.indexOf(document.location.hostname) === -1) {
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+                ga('create', '{{google_analytics}}', 'auto');
+                ga('send', 'pageview');
             }
         </script>
         {{/if}}
@@ -324,22 +311,21 @@
         {{#if is_print}}
         {{#if mathjax_support}}
         <script>
-            window.addEventListener('load', function () {
-                MathJax.Hub.Register.StartupHook('End', function () {
-                    window.setTimeout(window.print, 100);
-                });
+        window.addEventListener('load', function() {
+            MathJax.Hub.Register.StartupHook('End', function() {
+                window.setTimeout(window.print, 100);
             });
+        });
         </script>
         {{else}}
         <script>
-            window.addEventListener('load', function () {
-                window.setTimeout(window.print, 100);
-            });
+        window.addEventListener('load', function() {
+            window.setTimeout(window.print, 100);
+        });
         </script>
         {{/if}}
         {{/if}}
 
     </div>
-</body>
-
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- sync `index.hbs` with mdBook v0.4.41 and restore custom page table of contents
- refresh base CSS files and keep Japanese/monospace font overrides
- use static sidebar and Lean Playground button for offline-friendly navigation

## Testing
- `mdbook build` *(fails: Chapter file not found, ./README.md)*

------
https://chatgpt.com/codex/tasks/task_e_6893824fd984832cbb39a975a8b8b353