### PR TITLE
lも省略できる

### DIFF
--- a/LeanByExample/Declarative/Variable.lean
+++ b/LeanByExample/Declarative/Variable.lean
@@ -23,7 +23,7 @@ namespace variable1 --#
 variable {α : Type} (l : List α)
 
 /-- 連結リストの最後の要素を取り出す -/
-def last? (l : List α) : Option α :=
+def last? : Option α :=
   match l with
   | [] => none
   | [a] => some a


### PR DESCRIPTION
初めまして

nng_list_lengthと同様に、last?からも引数lが省略できると思います。
間違っていたらこのプルリクは却下してください。