### PR TITLE
[codex] grind_pattern に @[grind] 失敗例を追加

### DIFF
--- a/LeanByExample/Declarative/GrindPattern.lean
+++ b/LeanByExample/Declarative/GrindPattern.lean
@@ -20,8 +20,7 @@ example (x y z : Nat) (h₁ : R x y) (h₂ : R y z) : R x z := by
 /-
 ## `[grind]` 属性では登録できない例
 
-`[grind]` 属性を使うとパターンを自動で推測してくれますが、自動推測に失敗することがあります。
-このような場合は `grind_pattern` コマンドでパターンを明示する必要があります。
+多くの場合、わざわざ `grind_pattern` コマンドでパターンを手動指定しなくても `[grind]` 属性にパターンを自動で推測させることができますが、自動推測に失敗することがあります。このような場合は `grind_pattern` コマンドでパターンを明示する必要があります。
 
 {{#include ./GrindPattern/AttributeFailure.md}}
 -/

--- a/LeanByExample/Declarative/GrindPattern.lean
+++ b/LeanByExample/Declarative/GrindPattern.lean
@@ -18,6 +18,15 @@ example (x y z : Nat) (h₁ : R x y) (h₂ : R y z) : R x z := by
   grind
 
 /-
+## `[grind]` 属性では登録できない例
+
+`[grind]` 属性を使うとパターンを自動で推測してくれますが、自動推測に失敗することがあります。
+このような場合は `grind_pattern` コマンドでパターンを明示する必要があります。
+
+{{#include ./GrindPattern/AttributeFailure.md}}
+-/
+
+/-
 ## where による制御
 
 `grind_pattern` コマンドは、`grind` タクティクに定理を再利用させることができるという点では `[grind]` 属性とできることが同じですが、`grind_pattern` コマンドの方がより細かい制御を行えます。

--- a/LeanByExample/Declarative/GrindPattern/AttributeFailure.lean
+++ b/LeanByExample/Declarative/GrindPattern/AttributeFailure.lean
@@ -1,5 +1,3 @@
-namespace GrindPatternAttributeFailure
-
 variable {α : Type}
 
 /-- 二項関係 `R` がリストの隣接要素に対して成立するという述語。 -/
@@ -46,5 +44,3 @@ theorem IsChain.append {xs ys : List α} :
       | _, [] => IsChain R xs
       | some x, b :: _ => IsChain R xs ∧ R x b ∧ IsChain R ys := by
   fun_induction last? xs with grind
-
-end GrindPatternAttributeFailure

--- a/LeanByExample/Declarative/GrindPattern/AttributeFailure.lean
+++ b/LeanByExample/Declarative/GrindPattern/AttributeFailure.lean
@@ -1,0 +1,50 @@
+namespace GrindPatternAttributeFailure
+
+variable {α : Type}
+
+/-- 二項関係 `R` がリストの隣接要素に対して成立するという述語。 -/
+inductive IsChain (R : α → α → Prop) : List α → Prop
+  | nil : IsChain R []
+  | single (a : α) : IsChain R [a]
+  | cons_cons {a b : α} {l : List α} (hab : R a b) (hchain : IsChain R (b :: l)) :
+    IsChain R (a :: b :: l)
+
+attribute [grind cases] IsChain
+attribute [simp] IsChain.nil IsChain.single
+attribute [grind <=] IsChain.cons_cons IsChain.single IsChain.nil
+
+variable {R : α → α → Prop}
+
+/-- リストの最後の要素を取得する。 -/
+@[simp]
+def last? (xs : List α) : Option α :=
+  match xs with
+  | [] => none
+  | [a] => some a
+  | _ :: b :: bs => last? (b :: bs)
+
+theorem last?_cons_exists (xs : List α) (x : α) :
+    ∃ y : α, some y = last? (x :: xs) := by
+  induction xs generalizing x with simp_all
+
+-- `[grind]` 属性は、登録すべきパターンを見つけられない。
+/-⋆-//--
+error: invalid `grind` theorem, failed to find an usable pattern using different modifiers
+-/
+#guard_msgs in --#
+attribute [grind] last?_cons_exists
+
+-- `grind_pattern` コマンドなら、`last? (x :: xs)` を見たときに
+-- `last?_cons_exists` を使うよう明示的に指定できる。
+grind_pattern last?_cons_exists => last? (x :: xs)
+
+@[grind =]
+theorem IsChain.append {xs ys : List α} :
+    IsChain R (xs ++ ys) ↔
+      match last? xs, ys with
+      | none, _ => IsChain R ys
+      | _, [] => IsChain R xs
+      | some x, b :: _ => IsChain R xs ∧ R x b ∧ IsChain R ys := by
+  fun_induction last? xs with grind
+
+end GrindPatternAttributeFailure


### PR DESCRIPTION
## Summary

- `grind_pattern` ページに、`@[grind]` 属性では usable pattern を見つけられずエラーになる例を追加しました。
- `last? (x :: xs)` を明示的に `grind_pattern` 登録することで、後続の `IsChain.append` の証明に使えることを示しました。
- 例専用 namespace を使い、既存の `List.last?` / `List.IsChain` 例との名前衝突を避けています。

Closes #2197.

## Validation

- `lake env lean LeanByExample\Declarative\GrindPattern\AttributeFailure.lean`
- `lake env lean LeanByExample\Declarative\GrindPattern.lean`
- `lake build LeanByExample.Declarative.GrindPattern.AttributeFailure`
- `lake build LeanByExample.Declarative.GrindPattern`
- `lake exe mdgen LeanByExample booksrc --count --exercise`
- `lake build`